### PR TITLE
Fix segfaults in latest mojo nightly

### DIFF
--- a/example.mojo
+++ b/example.mojo
@@ -2,16 +2,17 @@ from sdl import *
 
 # TODO: collision rect/point
 
+
 def main():
     alias screen_width = 640
     alias screen_height = 480
 
-    var sdl = SDL(video=True, audio=True, timer=True, events=True)
+    var sdl = SDL(video=True, audio=True, timer=True, events=True, gfx=True, img=True, mix=True, ttf=True)
     var window = Window(sdl, 'SDL Test', screen_width, screen_height)
     var clock = Clock(sdl, target_fps=60)
     var held_keys = SIMD[DType.bool, 512]()
 
-    var apple = Surface(sdl, sdl.img.load_image('assets/apple.png'))
+    var apple = Surface(sdl, sdl.img.load_image(('assets/apple.png').unsafe_cstr_ptr().bitcast[DType.uint8]()))
     var rotated_apple = Surface(sdl, sdl.gfx.rotozoom_surface(apple, 90, 1, True))
     var font = ttf.Font(sdl, "assets/Beef'd.ttf", 24)
     var hello = font.render_solid('Hello, World!', Color(255, 0, 255, 255))
@@ -28,7 +29,7 @@ def main():
     while playing:
         for event in sdl.event_list():
             if event[].isa[QuitEvent]():
-                playing = False
+                playing = 0
             elif event[].isa[KeyDownEvent]():
                 var e = event[][KeyDownEvent]
                 held_keys[int(e.key)] = True

--- a/src/events.mojo
+++ b/src/events.mojo
@@ -244,6 +244,7 @@ alias Event = Variant[
 
 
 @value
+@register_passable("trivial")
 struct _Event:
     """Total size is 56 bytes."""
 
@@ -258,33 +259,33 @@ struct _Event:
         self.data1 = 0
         self.data2 = 0
 
-    fn to_nonc(owned self) -> Event:
-        var ptr = Ptr.address_of(self)
-        if self.type == EventType.QUIT:
-            return ptr.bitcast[QuitEvent]()[]
-        elif self.type == EventType.WINDOWEVENT:
-            return ptr.bitcast[WindowEvent]()[]
-        elif self.type == EventType.KEYDOWN:
-            return ptr.bitcast[KeyDownEvent]()[]
-        elif self.type == EventType.KEYUP:
-            return ptr.bitcast[KeyUpEvent]()[]
-        elif self.type == EventType.TEXTEDITING:
-            return ptr.bitcast[TextEditingEvent]()[]
-        elif self.type == EventType.TEXTINPUT:
-            return ptr.bitcast[TextInputEvent]()[]
-        elif self.type == EventType.KEYMAPCHANGED:
-            return ptr.bitcast[KeyMapChangedEvent]()[]
-        elif self.type == EventType.MOUSEMOTION:
-            return ptr.bitcast[MouseMotionEvent]()[]
-        elif self.type == EventType.MOUSEBUTTONDOWN or self.type == EventType.MOUSEBUTTONUP:
-            return ptr.bitcast[MouseButtonEvent]()[]
-        elif self.type == EventType.MOUSEWHEEL:
-            return ptr.bitcast[MouseWheelEvent]()[]
-        elif self.type == EventType.AUDIODEVICEADDED or self.type == EventType.AUDIODEVICEREMOVED:
-            return ptr.bitcast[AudioDeviceEvent]()[]
+    @staticmethod
+    fn to_event(_event: Ptr[_Event]) -> Event:
+        if _event[].type == EventType.QUIT:
+            return _event.bitcast[QuitEvent]()[]
+        elif _event[].type == EventType.WINDOWEVENT:
+            return _event.bitcast[WindowEvent]()[]
+        elif _event[].type == EventType.KEYDOWN:
+            return _event.bitcast[KeyDownEvent]()[]
+        elif _event[].type == EventType.KEYUP:
+            return _event.bitcast[KeyUpEvent]()[]
+        elif _event[].type == EventType.TEXTEDITING:
+            return _event.bitcast[TextEditingEvent]()[]
+        elif _event[].type == EventType.TEXTINPUT:
+            return _event.bitcast[TextInputEvent]()[]
+        elif _event[].type == EventType.KEYMAPCHANGED:
+            return _event.bitcast[KeyMapChangedEvent]()[]
+        elif _event[].type == EventType.MOUSEMOTION:
+            return _event.bitcast[MouseMotionEvent]()[]
+        elif _event[].type == EventType.MOUSEBUTTONDOWN or _event[].type == EventType.MOUSEBUTTONUP:
+            return _event.bitcast[MouseButtonEvent]()[]
+        elif _event[].type == EventType.MOUSEWHEEL:
+            return _event.bitcast[MouseWheelEvent]()[]
+        elif _event[].type == EventType.AUDIODEVICEADDED or _event[].type == EventType.AUDIODEVICEREMOVED:
+            return _event.bitcast[AudioDeviceEvent]()[]
         else:
-            print("Unhandled event type: " + str(self.type))
-            return ptr.bitcast[QuitEvent]()[]
+            print("Unhandled event type: " + str(_event[].type))
+            return _event.bitcast[QuitEvent]()[]
 
 
 @value

--- a/src/gfx/__init__.mojo
+++ b/src/gfx/__init__.mojo
@@ -14,6 +14,9 @@ struct _GFX:
     var _circle_color: SDL_Fn["circleColor", fn (UnsafePointer[_Renderer], Int16, Int16, Int16, UInt32) -> IntC]
     var _circle_rgba: SDL_Fn["circleRGBA", fn (UnsafePointer[_Renderer], Int16, Int16, Int16, UInt8, UInt8, UInt8, UInt8) -> IntC]
 
+    fn __init__(inout self, none: NoneType):
+        __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
+
     fn __init__(inout self, error: SDL_Error):
         self._handle = DLHandle("/lib/x86_64-linux-gnu/libSDL2_gfx-1.0.so.0")
         self.error = error

--- a/src/img/__init__.mojo
+++ b/src/img/__init__.mojo
@@ -1,11 +1,12 @@
 """Defines SDL_img bindings and wrappers for use in Mojo."""
 
 from sys.ffi import DLHandle
-from .._sdl import SDL_Fn, _SDL
+from .._sdl import SDL_Fn
 from ..surface import _Surface
 
 
 struct _IMG:
+    var _initialized: Bool
     var _handle: DLHandle
     var error: SDL_Error
 
@@ -13,12 +14,20 @@ struct _IMG:
     var _img_quit: SDL_Fn["IMG_Quit", fn () -> NoneType]
     var _img_load: SDL_Fn["IMG_Load", fn (Ptr[CharC]) -> Ptr[_Surface]]
 
-    fn __init__(inout self, error: SDL_Error, jpeg: Bool = True, png: Bool = True, tif: Bool = False, webp: Bool = False) raises:
+    fn __init__(inout self, none: NoneType):
+        self._initialized = False
+        __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
+
+    fn __init__[init: Bool](inout self, error: SDL_Error):
+        self._initialized = True
         self._handle = DLHandle("/lib/x86_64-linux-gnu/libSDL2_image-2.0.so.0")
         self.error = error
         self._img_init = self._handle
         self._img_quit = self._handle
         self._img_load = self._handle
+
+    fn __init__(inout self, error: SDL_Error, jpeg: Bool = True, png: Bool = True, tif: Bool = False, webp: Bool = False) raises:
+        self.__init__[False](error)
         var flags: Int32 = 0
         flags |= 0x00000001 * jpeg
         flags |= 0x00000002 * png
@@ -27,7 +36,8 @@ struct _IMG:
         self.init(flags)
 
     fn __del__(owned self):
-        self.quit()
+        if self._initialized:
+            self.quit()
 
     @always_inline
     fn init(self, flags: Int32) raises:
@@ -37,7 +47,11 @@ struct _IMG:
     @always_inline
     fn quit(self):
         self._img_quit.call()
- 
+
     @always_inline
     fn load_image(self, file: Ptr[CharC]) raises -> Ptr[_Surface]:
         return self.error.if_null(self._img_load.call(file), "Could not load image")
+
+
+
+

--- a/src/render.mojo
+++ b/src/render.mojo
@@ -43,7 +43,7 @@ struct Renderer[lif: AnyLifetime[False].type]:
         elif type.is_floating_point():
             self.sdl[]._sdl.render_copy_f(self._renderer_ptr, texture._texture_ptr, opt2ptr(src), Ptr[FRect]())
 
-    fn copy[type: DType](self, texture: Texture, src: Optional[Rect], dst: DRect[type]) raises:
+    fn copy[type: DType = DType.int32](self, texture: Texture, src: Optional[Rect], dst: DRect[type]) raises:
         @parameter
         if type.is_integral():
             self.sdl[]._sdl.render_copy(self._renderer_ptr, texture._texture_ptr, opt2ptr(src), adr(dst.cast[DType.int32]()))
@@ -148,7 +148,7 @@ struct Renderer[lif: AnyLifetime[False].type]:
         self.sdl[]._sdl.get_renderer_output_size(self._renderer_ptr, adr(w), adr(h))
         return int(w), int(h)
 
-    fn draw_point[type: DType](self, x: Scalar[type], y: Scalar[type]) raises:
+    fn draw_point[type: DType = DType.float32](self, x: Scalar[type], y: Scalar[type]) raises:
         @parameter
         if type.is_integral():
             self.sdl[]._sdl.render_draw_point(self._renderer_ptr, x.cast[DType.int32](), y.cast[DType.int32]())
@@ -161,15 +161,12 @@ struct Renderer[lif: AnyLifetime[False].type]:
     fn draw_points(self, points: List[FPoint]) raises:
         self.sdl[]._sdl.render_draw_points_f(self._renderer_ptr, points.unsafe_ptr(), len(points))
 
-    fn draw_line[type: DType](self, x1: Scalar[type], y1: Scalar[type], x2: Scalar[type], y2: Scalar[type]) raises:
+    fn draw_line[type: DType = DType.float32](self, x1: Scalar[type], y1: Scalar[type], x2: Scalar[type], y2: Scalar[type]) raises:
         @parameter
         if type.is_integral():
             self.sdl[]._sdl.render_draw_line(self._renderer_ptr, x1.cast[DType.int32](), y1.cast[DType.int32](), x2.cast[DType.int32](), y2.cast[DType.int32]())
         elif type.is_floating_point():
             self.sdl[]._sdl.render_draw_line_f(self._renderer_ptr, x1.cast[DType.float32](), y1.cast[DType.float32](), x2.cast[DType.float32](), y2.cast[DType.float32]())
-
-    fn draw_circle[type: DType](self, center: DPoint[type], radius: Scalar) raises:
-        self.sdl[].gfx.circle_color(self._renderer_ptr, center.x.cast[DType.int16](), center.y.cast[DType.int16](), radius.cast[DType.int16](), self.get_color().as_uint32())
 
     fn draw_lines(self, points: List[Point]) raises:
         self.sdl[]._sdl.render_draw_lines(self._renderer_ptr, points.unsafe_ptr(), len(points))
@@ -177,7 +174,10 @@ struct Renderer[lif: AnyLifetime[False].type]:
     fn draw_lines(self, points: List[FPoint]) raises:
         self.sdl[]._sdl.render_draw_lines_f(self._renderer_ptr, points.unsafe_ptr(), len(points))
 
-    fn draw_rect[type: DType](self, rect: DRect[type]) raises:
+    fn draw_circle[type: DType = DType.float32](self, center: DPoint[type], radius: Scalar) raises:
+        self.sdl[].gfx.circle_color(self._renderer_ptr, center.x.cast[DType.int16](), center.y.cast[DType.int16](), radius.cast[DType.int16](), self.get_color().as_uint32())
+
+    fn draw_rect[type: DType = DType.float32](self, rect: DRect[type]) raises:
         @parameter
         if type.is_integral():
             self.sdl[]._sdl.render_draw_rect(self._renderer_ptr, rect.cast[DType.int32]())
@@ -190,7 +190,7 @@ struct Renderer[lif: AnyLifetime[False].type]:
     fn draw_rects(self, rects: List[FRect]) raises:
         self.sdl[]._sdl.render_draw_rects_f(self._renderer_ptr, rects.unsafe_ptr(), len(rects))
 
-    fn fill_rect[type: DType](self, rect: DRect[type]) raises:
+    fn fill_rect[type: DType = DType.float32](self, rect: DRect[type]) raises:
         @parameter
         if type.is_integral():
             self.sdl[]._sdl.render_fill_rect(self._renderer_ptr, rect.cast[DType.int32]())

--- a/src/texture.mojo
+++ b/src/texture.mojo
@@ -121,41 +121,41 @@ struct BlendMode:
 
     var value: IntC
 
-    alias NONE = 0x00000000
+    alias NONE: IntC = 0x00000000
     """No blending.
 
         dstRGBA = srcRGBA
     """
 
-    alias BLEND = 0x00000001
+    alias BLEND: IntC = 0x00000001
     """Alpha blending.
 
         dstRGB = (srcRGB * srcA) + (dstRGB * (1-srcA))
         dstA = srcA + (dstA * (1-srcA))
     """
 
-    alias ADD = 0x00000002
+    alias ADD: IntC = 0x00000002
     """Additive blending.
 
         dstRGB = (srcRGB * srcA) + dstRGB
         dstA = dstA
     """
 
-    alias MOD = 0x00000004
+    alias MOD: IntC = 0x00000004
     """Color modulate.
 
         dstRGB = srcRGB * dstRGB
         dstA = dstA
     """
 
-    alias MUL = 0x00000008
+    alias MUL: IntC = 0x00000008
     """Color multiply.
 
         dstRGB = (srcRGB * dstRGB) + (dstRGB * (1-srcA))
         dstA = dstA
     """
 
-    alias INVALID = 0x7FFFFFFF
+    alias INVALID: IntC = 0x7FFFFFFF
     """Invalid."""
 
 
@@ -166,13 +166,13 @@ struct ScaleMode:
 
     var value: IntC
 
-    alias Nearest = 0
+    alias Nearest: IntC = 0
     """Nearest pixel sampling."""
 
-    alias Linear = 1
+    alias Linear: IntC = 1
     """Linear filtering."""
 
-    alias Best = 2
+    alias Best: IntC = 2
     """Anisotropic filtering."""
 
 
@@ -183,11 +183,11 @@ struct TextureModulate:
 
     var value: IntC
 
-    alias NONE = 0x00000000
+    alias NONE: IntC = 0x00000000
     """No modulation."""
 
-    alias COLOR = 0x00000001
+    alias COLOR: IntC = 0x00000001
     """srcC = srcC * color"""
 
-    alias ALPHA = 0x00000002
+    alias ALPHA: IntC = 0x00000002
     """srcA = srcA * alpha"""


### PR DESCRIPTION
Fix segfaults in latest mojo nightly caused by event pointers.
Allow omission of add-on libraries if they are not being used. This should eventually be improved to give a better error message instead of just segfaulting. Add fallback paths to look for the sdl library.
Add default dtypes to some rendering methods.
Add better implicit conversion for some enums.